### PR TITLE
Create flowbrasilchain_Non-Fungible_Tokens_2023-12-06.cdc

### DIFF
--- a/2023/q4-code-snippets/submissions/flowbrasilchain_Non-Fungible_Tokens_2023-12-06.cdc
+++ b/2023/q4-code-snippets/submissions/flowbrasilchain_Non-Fungible_Tokens_2023-12-06.cdc
@@ -1,0 +1,23 @@
+import FLOATIncinerator from 0x2d4c3caffbeab845
+import FLOAT from 0x2d4c3caffbeab845
+     
+transaction(id: UInt64) {
+  let Collection: &FLOAT.Collection
+  let Incinerator: &FLOATIncinerator.Incinerator
+
+
+  prepare(signer: AuthAccount) {
+    self.Collection = signer.borrow<&FLOAT.Collection>(from: FLOAT.FLOATCollectionStoragePath)
+                          ?? panic("Could not get the Collection from the signer.")
+   
+    if signer.borrow<&FLOATIncinerator.Incinerator>(from: FLOATIncinerator.IncineratorStoragePath) == nil {
+      signer.save(<- FLOATIncinerator.createIncinerator(), to: FLOATIncinerator.IncineratorStoragePath)
+      signer.link<&FLOATIncinerator.Incinerator{FLOATIncinerator.IncineratorPublic}>(FLOATIncinerator.IncineratorPublicPath, target: FLOATIncinerator.IncineratorStoragePath)
+    }
+    self.Incinerator = signer.borrow<&FLOATIncinerator.Incinerator>(from: FLOATIncinerator.IncineratorStoragePath)!
+  }
+ 
+  execute {
+    self.Incinerator.burn(collection: self.Collection, ids: [id])
+  }
+}


### PR DESCRIPTION
This transaction allows a user to burn (destroy) a specific NFT in their FLOAT collection, using the incineration mechanism provided by the FLOATIncinerator contract. It's an example of interaction between contracts and the handling of non-fungible tokens (NFTs) on the Flow Blockchain.