### PR TITLE
Create {Alex072002}_{Account Linking}_{2023-12-12}.cdc

### DIFF
--- a/2023/q4-code-snippets/{Alex072002}_{Account Linking}_{2023-12-12}.cdc
+++ b/2023/q4-code-snippets/{Alex072002}_{Account Linking}_{2023-12-12}.cdc
@@ -1,0 +1,8 @@
+#allowAccountLinking
+
+transaction {
+    prepare(signer: AuthAccount) {
+        let capability = signer.linkAccount(/private/accountCapA)!
+        signer.inbox.publish(capability, name: "accountCapA", recipient: 0x1)
+    }
+}


### PR DESCRIPTION
#allowAccountLinking

transaction {
    prepare(signer: AuthAccount) {
        let capability = signer.linkAccount(/private/accountCapA)!
        signer.inbox.publish(capability, name: "accountCapA", recipient: 0x1)
    }
}
